### PR TITLE
change spiread() delay time

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ GND: Ground.
 ```
 
 Created by [Yurii Salimov](mailto:yuriy.alex.salimov@gmail.com).
+
+Modified by [Konosubakonoakua](https://github.com/konosubakonoakua).
+
+> - read more quickly
+> - use hardware SPI by setting `#define USE_HW_SPI 1`
+> - use freertos delay by setting `#define USE_FREERTOS_DELAY 1`

--- a/src/MAX6675_Thermocouple.cpp
+++ b/src/MAX6675_Thermocouple.cpp
@@ -76,12 +76,14 @@ byte MAX6675_Thermocouple::spiread() {
 	byte value = 0;
 	for (int i = 7; i >= 0; i--) {
 		digitalWrite(this->SCK_pin, LOW);
-		delay(1);
+		// delay(1);
+        delayMicroseconds(1);
 		if (digitalRead(this->SO_pin)) {
 			value |= (1 << i);
 		}
 		digitalWrite(this->SCK_pin, HIGH);
-		delay(1);
+        delayMicroseconds(1);
+		// delay(1);
 	}
 	return value;
 }

--- a/src/MAX6675_Thermocouple.h
+++ b/src/MAX6675_Thermocouple.h
@@ -45,8 +45,14 @@
 	#include <WProgram.h>
 #endif
 
-#define MAX6675_DEFAULT_READINGS_NUMBER	5
-#define MAX6675_DEFAULT_DELAY_TIME	5
+#define MAX6675_DEFAULT_READINGS_NUMBER	1
+#define MAX6675_DEFAULT_DELAY_TIME	1
+
+#define USE_HW_SPI 1
+
+#if USE_HW_SPI == 1
+#include "SPI.h"
+#endif
 
 class MAX6675_Thermocouple final {
 
@@ -56,6 +62,9 @@ class MAX6675_Thermocouple final {
 		int SO_pin;
 		volatile int readingsNumber;
 		volatile long delayTime;
+		#if USE_HW_SPI == 1
+		SPIClass* _spi;
+		#endif
 
 	public:
 		/**
@@ -69,7 +78,12 @@ class MAX6675_Thermocouple final {
 			int CS_pin,
 			int SO_pin
 		);
-
+		#if USE_HW_SPI == 1
+			MAX6675_Thermocouple(
+				SPIClass* spi,
+				int CS_pin
+			);
+		#endif
 		/**
 			Constructor.
 			@param SCK_pin - SCK digital port number.
@@ -139,7 +153,9 @@ class MAX6675_Thermocouple final {
 		inline double celsiusToFahrenheit(double celsius);
 
 		byte spiread();
-
+		#if USE_HW_SPI == 1
+		int spiread_hw();
+		#endif
 		inline void sleep();
 
 		/**


### PR DESCRIPTION
use delay() in the spiread() function caused speed issue, I need hundred millis to read one time.
I replace delay() with delayMicroseconds(), and tested on esp32, works fine.